### PR TITLE
universal-windows: GetProcessTimes is not supported

### DIFF
--- a/src/cpu_timer.cpp
+++ b/src/cpu_timer.cpp
@@ -18,6 +18,7 @@
 #include <boost/io/ios_state.hpp>
 #include <boost/throw_exception.hpp>
 #include <boost/cerrno.hpp>
+#include <boost/predef.h>
 #include <cstring>
 #include <sstream>
 #include <cassert>
@@ -122,6 +123,7 @@ namespace
 
 # if defined(BOOST_WINDOWS_API)
 
+#  if BOOST_PLAT_WINDOWS_DESKTOP
     FILETIME creation, exit;
     if (::GetProcessTimes(::GetCurrentProcess(), &creation, &exit,
             (LPFILETIME)&current.system, (LPFILETIME)&current.user))
@@ -130,6 +132,7 @@ namespace
       current.system *= 100;
     }
     else
+#  endif
     {
       current.system = current.user = boost::timer::nanosecond_type(-1);
     }


### PR DESCRIPTION
While it might be possible to use GetProcAddress() to find the function (refer: http://stackoverflow.com/questions/12338953/is-there-any-way-for-a-winrt-app-to-measure-its-own-cpu-usage) you will not pass app certification when using that function so it might be safer to just not use it for now.
