### PR TITLE
Avoid link-time chrono dependencies

### DIFF
--- a/src/cpu_timer.cpp
+++ b/src/cpu_timer.cpp
@@ -13,6 +13,10 @@
 // the library is being built (possibly exporting rather than importing code)
 #define BOOST_TIMER_SOURCE
 
+// define BOOST_CHRONO_HEADER_ONLY so that chrono dependencies are not
+// propagated to library users
+#define BOOST_CHRONO_HEADER_ONLY
+
 #include <boost/timer/timer.hpp>
 #include <boost/chrono/chrono.hpp>
 #include <boost/io/ios_state.hpp>


### PR DESCRIPTION
timer used to be independent from chrono. The tiny dependency used in the implementation can be isolated defining BOOST_CHRONO_HEADER_ONLY