### PR TITLE
Revert "Avoid link-time chrono dependencies"

### DIFF
--- a/src/cpu_timer.cpp
+++ b/src/cpu_timer.cpp
@@ -13,10 +13,6 @@
 // the library is being built (possibly exporting rather than importing code)
 #define BOOST_TIMER_SOURCE
 
-// define BOOST_CHRONO_HEADER_ONLY so that chrono dependencies are not
-// propagated to library users
-#define BOOST_CHRONO_HEADER_ONLY
-
 #include <boost/timer/timer.hpp>
 #include <boost/chrono/chrono.hpp>
 #include <boost/io/ios_state.hpp>


### PR DESCRIPTION
This reverts commit 98954984a4b55d01380bd8f18c884dc8519133ea, from PR #5.

It's causing a link error for Visual C++. This branch will be used for 1.66.0, but if it's fixed some other way for the next release then it doesn't need to be accepted.