### PR TITLE
Remove unused using-declaration for `error_code`

### DIFF
--- a/src/cpu_timer.cpp
+++ b/src/cpu_timer.cpp
@@ -34,7 +34,6 @@
 
 using boost::timer::nanosecond_type;
 using boost::timer::cpu_times;
-using boost::system::error_code;
 
 namespace
 {


### PR DESCRIPTION
_Sorry for not following the official contributing process, I thought this small change might not worth it. Feel free to close if unwanted._ 

`boost::system::error_code` is included in the namespace, even though it is not even used in this file. 

The problem I encounter because of this: When configuring `boost/chrono` to be header-only, the `error_code` symbol is not included anymore and the `cpu_timer.cpp` doesn't compile.